### PR TITLE
CB off by one

### DIFF
--- a/gobreaker/gobreaker.go
+++ b/gobreaker/gobreaker.go
@@ -99,7 +99,7 @@ func NewCircuitBreaker(cfg Config, logger logging.Logger) *gobreaker.CircuitBrea
 		Interval: time.Duration(cfg.Interval) * time.Second,
 		Timeout:  time.Duration(cfg.Timeout) * time.Second,
 		ReadyToTrip: func(counts gobreaker.Counts) bool {
-			return counts.ConsecutiveFailures > uint32(cfg.MaxErrors)
+			return counts.ConsecutiveFailures >= uint32(cfg.MaxErrors)
 		},
 	}
 


### PR DESCRIPTION
Enable the CB when the consecutive errors equal the max_errors as proposed by @breml a [while ago](https://github.com/krakendio/krakend-circuitbreaker/issues/3)